### PR TITLE
Default defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -105,7 +105,7 @@ ensure_gpgcheck_never_disabled: true
 ensure_redhat_gpgkey_installed: true
 grub2_audit_argument: true
 grub2_audit_backlog_limit_argument: true
-grub2_disable_interactive_boot: false
+grub2_disable_interactive_boot: true
 grub2_kernel_trust_cpu_rng: true
 grub2_page_poison_argument: true
 grub2_pti_argument: true
@@ -134,7 +134,7 @@ mount_option_home_nodev: true
 mount_option_home_nosuid: true
 mount_option_nodev_nonroot_local_partitions: true
 mount_option_tmp_nodev: true
-mount_option_tmp_noexec: false
+mount_option_tmp_noexec: true
 mount_option_tmp_nosuid: true
 mount_option_var_log_audit_nodev: true
 mount_option_var_log_audit_noexec: true
@@ -144,7 +144,7 @@ mount_option_var_log_noexec: true
 mount_option_var_log_nosuid: true
 mount_option_var_nodev: true
 mount_option_var_tmp_nodev: true
-mount_option_var_tmp_noexec: false
+mount_option_var_tmp_noexec: true
 mount_option_var_tmp_nosuid: true
 no_empty_passwords: true
 no_reboot_needed: true
@@ -155,9 +155,9 @@ package_audit_installed: true
 package_chrony_installed: true
 package_fapolicyd_installed: true
 package_firewalld_installed: true
-package_gssproxy_removed: false
+package_gssproxy_removed: true
 package_iprutils_removed: true
-package_nfs_utils_removed: false
+package_nfs_utils_removed: true
 package_policycoreutils_installed: true
 package_rsyslog_installed: true
 package_sendmail_removed: true
@@ -181,7 +181,7 @@ ssh_client_use_strong_rng_sh: true
 sshd_disable_empty_passwords: true
 sshd_disable_gssapi_auth: true
 sshd_disable_kerb_auth: true
-sshd_disable_root_login: false
+sshd_disable_root_login: true
 sshd_enable_strictmodes: true
 sshd_enable_warning_banner: true
 sshd_rekey_limit: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -94,7 +94,7 @@ coredump_disable_backtraces: true
 coredump_disable_storage: true
 disable_ctrlaltdel_burstaction: true
 disable_ctrlaltdel_reboot: true
-disable_host_auth: false
+disable_host_auth: true
 disable_strategy: true
 disable_users_coredumps: true
 enable_fips_mode: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -105,7 +105,7 @@ ensure_gpgcheck_never_disabled: true
 ensure_redhat_gpgkey_installed: true
 grub2_audit_argument: true
 grub2_audit_backlog_limit_argument: true
-grub2_disable_interactive_boot: true
+grub2_disable_interactive_boot: false
 grub2_kernel_trust_cpu_rng: true
 grub2_page_poison_argument: true
 grub2_pti_argument: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -134,7 +134,7 @@ mount_option_home_nodev: true
 mount_option_home_nosuid: true
 mount_option_nodev_nonroot_local_partitions: true
 mount_option_tmp_nodev: true
-mount_option_tmp_noexec: true
+mount_option_tmp_noexec: false
 mount_option_tmp_nosuid: true
 mount_option_var_log_audit_nodev: true
 mount_option_var_log_audit_noexec: true
@@ -144,7 +144,7 @@ mount_option_var_log_noexec: true
 mount_option_var_log_nosuid: true
 mount_option_var_nodev: true
 mount_option_var_tmp_nodev: true
-mount_option_var_tmp_noexec: true
+mount_option_var_tmp_noexec: false
 mount_option_var_tmp_nosuid: true
 no_empty_passwords: true
 no_reboot_needed: true
@@ -155,8 +155,9 @@ package_audit_installed: true
 package_chrony_installed: true
 package_fapolicyd_installed: true
 package_firewalld_installed: true
-package_gssproxy_removed: true
+package_gssproxy_removed: false
 package_iprutils_removed: true
+package_nfs_utils_removed: false
 package_policycoreutils_installed: true
 package_rsyslog_installed: true
 package_sendmail_removed: true
@@ -180,7 +181,7 @@ ssh_client_use_strong_rng_sh: true
 sshd_disable_empty_passwords: true
 sshd_disable_gssapi_auth: true
 sshd_disable_kerb_auth: true
-sshd_disable_root_login: true
+sshd_disable_root_login: false
 sshd_enable_strictmodes: true
 sshd_enable_warning_banner: true
 sshd_rekey_limit: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -94,7 +94,7 @@ coredump_disable_backtraces: true
 coredump_disable_storage: true
 disable_ctrlaltdel_burstaction: true
 disable_ctrlaltdel_reboot: true
-disable_host_auth: true
+disable_host_auth: false
 disable_strategy: true
 disable_users_coredumps: true
 enable_fips_mode: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -364,6 +364,7 @@
   - low_disruption | bool
   - medium_severity | bool
   - no_reboot_needed | bool
+  - ansible_distribution == "RedHat"
 
 - name: Ensure gnutls-utils is installed
   package:
@@ -440,6 +441,7 @@
   - low_disruption | bool
   - medium_severity | bool
   - no_reboot_needed | bool
+  - ansible_distribution == "RedHat"
 
 - name: Ensure abrt-addon-ccpp is removed
   package:
@@ -796,7 +798,7 @@
   - no_reboot_needed | bool
   - unknown_strategy | bool
   - '"yum" in ansible_facts.packages'
-  - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "Scientific" or yum_config_file.stat.exists)
+  - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "Scientific" or ansible_distribution == "Rocky" or yum_config_file.stat.exists)
   tags:
   - CCE-80790-9
   - CJIS-5.10.4.1
@@ -931,7 +933,7 @@
   - no_reboot_needed | bool
   - unknown_strategy | bool
   - '"yum" in ansible_facts.packages'
-  - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "Scientific" or yum_config_file.stat.exists)
+  - (ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "Scientific" or ansible_distribution == "Rocky" or yum_config_file.stat.exists)
   tags:
   - CCE-80791-7
   - DISA-STIG-RHEL-08-010371
@@ -10350,6 +10352,7 @@
   - low_disruption | bool
   - low_severity | bool
   - no_reboot_needed | bool
+  - package_nfs_utils_removed | bool
 
 - name: Ensure chrony is installed
   package:


### PR DESCRIPTION
i mixed changes required for RockyLinux and changed required for the SDE in the last pull. 
this PR reverts to upstream defaults and to "most secure" settings for the few tests added (eg, package_nfs_utils_removed).

in real-life, we will install this role using ansible roles. here are the relevant kickstart lines

    238 echo "Configuring requirements.yml for ansible-role-rocky8-cui"
    239 REQUIREMENTS_YML=/root/requirements.yml
    240 wget -O $REQUIREMENTS_YML http://$SERVER/kickstarts/files/${DISTRO}/ansible_cui_requirements.yml
    241 
    242 echo "Installing ansible role ansible-role-rocky8-cui"
    243 ansible-galaxy install -r $REQUIREMENTS_YML -p /usr/share/ansible/roles

and override these settings (group_vars ?)

grub2_disable_interactive_boot: false
mount_option_tmp_noexec: false
mount_option_var_tmp_noexec: false
package_gssproxy_removed: false
package_nfs_utils_removed: false
sshd_disable_root_login: false
